### PR TITLE
chore(config): add tencent pkg query to plugin config

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -107,6 +107,9 @@
             <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
             <uses-permission android:name="android.permission.READ_PHONE_STATE" />
             <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+            <queries>
+                <package android:name="com.tencent.mm" />
+            </queries>
         </config-file>
 
         <config-file target="AndroidManifest.xml" parent="/manifest/application">


### PR DESCRIPTION
This repo: we have freshly forked from the original wechat cordova plugin (https://github.com/xu-li/cordova-plugin-wechat) since that plugin has been updated as recently as July 2023, and this PR applies to this new fork the commit that we had already added to our former fork (https://github.com/AugBrianSun/cordova-plugin-wechat). 