### PR TITLE
fix(sdk): make recommended SDK updates

### DIFF
--- a/android-build.gradle
+++ b/android-build.gradle
@@ -5,5 +5,4 @@ repositories {
 
 dependencies {
     api 'com.tencent.mm.opensdk:wechat-sdk-android-without-mta:+'
-    implementation 'com.tencent.mm.opensdk:wechat-sdk-android-with-mta:+'
 }

--- a/android-build.gradle
+++ b/android-build.gradle
@@ -1,7 +1,9 @@
 repositories {
     jcenter()
+    mavenCentral()
 }
 
 dependencies {
+    api 'com.tencent.mm.opensdk:wechat-sdk-android-without-mta:+'
     implementation 'com.tencent.mm.opensdk:wechat-sdk-android-with-mta:+'
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -118,7 +118,8 @@
                 android:label="@string/launcher_name"
                 android:exported="true"
                 android:taskAffinity="$PACKAGE_NAME"
-                android:launchMode="singleTask">
+                android:launchMode="singleTask"
+                android:theme="@android:style/Theme.Translucent.NoTitleBar">
                 <intent-filter>
                     <action android:name="android.intent.action.VIEW"/>
                     <category android:name="android.intent.category.DEFAULT"/>


### PR DESCRIPTION
No ticket, in further debugging of the production build via Android Studio / LogCat, we noticed the following:

<img width="1711" alt="Screenshot 2023-09-28 at 12 07 51 PM" src="https://github.com/xu-li/cordova-plugin-wechat/assets/25204704/850609c0-6801-4534-81ad-ddc244c06a15">

Note that I highlighted what I thought was the most important error, but that other errors were being thrown from the `com.tencent.mm` package.

I remembered seeing something on the WeChat Android development guide related to that package: https://developers.weixin.qq.com/doc/oplatform/en/Mobile_App/Access_Guide/Android.html

Notably the addition of the `com.tencent.mm.opensdk:wechat-sdk-android-without-mta:+` API dependency to the gradle file. Also something about Maven vs. jCentral but maybe less important (I included it here anyway)?