### PR TITLE
fix(intent_filters): remove intent-filter for Android 13+

### DIFF
--- a/android-build.gradle
+++ b/android-build.gradle
@@ -4,5 +4,5 @@ repositories {
 }
 
 dependencies {
-    api 'com.tencent.mm.opensdk:wechat-sdk-android-without-mta:+'
+    api 'com.tencent.mm.opensdk:wechat-sdk-android-without-mta:6.8.0'
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -120,11 +120,6 @@
                 android:taskAffinity="$PACKAGE_NAME"
                 android:launchMode="singleTask"
                 android:theme="@android:style/Theme.Translucent.NoTitleBar">
-                <intent-filter>
-                    <action android:name="android.intent.action.VIEW"/>
-                    <category android:name="android.intent.category.DEFAULT"/>
-                    <data android:scheme="$WECHATAPPID"/>
-                </intent-filter>
             </activity>
             <activity
                 android:name=".wxapi.WXPayEntryActivity"


### PR DESCRIPTION
No ticket. Shultz and I were seeing errors like the following while debugging yesterday:

```
Received ACTIVITY intent 0x96bc4a0 Key{startActivity pkg=[com.tencent.mm](http://com.tencent.mm/) intent=flg=0x18000000 cmp=com.smartly.hybrid/.wxapi.WXEntryActivity flags=0x4000000 u=0} requestCode=3 res=-92 from uid 10359
Intent does not match component's intent filter: Intent { flg=0x18000000 cmp=com.smartly.hybrid/.wxapi.WXEntryActivity (has extras) }
```

This leads me to believe this plugin has an Android 13+ specific issue where it's trying to pass back control to the `com.smartly.hybrid/.wxapi.WXEntryActivity` component, but is passing more information than is specified in the plugin's `intent-filter`. 

https://medium.com/androiddevelopers/making-sense-of-intent-filters-in-android-13-8f6656903dde has a good explanation of what that means. Basically Android versions pre-13 don't care and will pass back control to the component in spite of the filter not matching. Android 13 is much more strict and will explicitly _not_ pass back control if the component's intent doesn't match the filter.

We're taking a gamble here that removing the `intent-filter` will fix the issue. I think it's safe to do because:
1. Prior to Android 13, the filter isn't enforced at all
2. The filter is currently broken on Android 13
3. And WeChat's [documentation for the new version of the SDK](https://developers.weixin.qq.com/doc/oplatform/en/Mobile_App/Access_Guide/Android.html) (6.8.0) don't specify an `intent-filter` at all.