### PR TITLE
chore(android): remove WRITE_EXTERNAL_STORAGE permission

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -106,7 +106,6 @@
             <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
             <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
             <uses-permission android:name="android.permission.READ_PHONE_STATE" />
-            <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
             <queries>
                 <package android:name="com.tencent.mm" />
             </queries>


### PR DESCRIPTION
No ticket, [this permission isn't needed when targeting SDK versions >= 30](https://developer.android.com/reference/android/Manifest.permission#WRITE_EXTERNAL_STORAGE) (we are targettng 33).

The existing of this permission is conflicting with [some other work](https://trello.com/c/FZgRZKp1/810-chore-request-access-to-photo-library-camera-on-android-13) I'm doing.