### PR TITLE
fix(android): immediately instantiate plugin on creation of main Cordova activity and register said activity for async results from Wechat

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -84,6 +84,7 @@
         <config-file target="res/xml/config.xml" parent="/*">
             <feature name="Wechat">
                 <param name="android-package" value="xu.li.cordova.wechat.Wechat"/>
+                <param name="onload" value="true"/>
             </feature>
             <preference name="WECHATAPPID" value="$WECHATAPPID"/>
         </config-file>


### PR DESCRIPTION
- **set onload=true for Android so Cordova will instantiate the plugin immediately on creation of main activity**
- **register the Cordova activity to handle a result from Wechat**
